### PR TITLE
Fix child_process.spawn args order

### DIFF
--- a/utils/wkhtmltopdf.js
+++ b/utils/wkhtmltopdf.js
@@ -5,7 +5,7 @@ wkhtmltopdf = function (html, options) {
 
     return new Promise(function (resolve, reject) {
         var bufs = [];
-        var proc = spawn("/bin/sh", ["-o", "pipefail", "-c", "wkhtmltopdf - - " + options.join(" ") + " | cat"]);
+        var proc = spawn("/bin/sh", ["-o", "pipefail", "-c", "wkhtmltopdf " + options.join(" ") + " - - | cat"]);
 
         proc.on("error", function (error) {
             reject(error);


### PR DESCRIPTION
Currently, passing wkhtmltopdf options throws an error (see issue https://github.com/zeplin/zeplin-html-to-pdf/issues/4).

The fix suggested there resolves the issue, so it would be great to get it merged.

Thanks!