### PR TITLE
feat: support for chinese characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ There are two ways in which these functions can be deployed to AWS.
 
 2 - Check out `template.yml` file and edit according to your needs then use `sam deploy`.
 
+## Fonts
+Provide the related font file under the `fonts` directory to support specific languages and characters.


### PR DESCRIPTION
Roboto, by default, does not support Chinese characters. Added Noto font for Chinese as suggested [here](https://en.wikipedia.org/wiki/Roboto#Language_support) to cover "square" (a.k.a. "tofu") issues.